### PR TITLE
Only put overlay on link, don't modify file content.

### DIFF
--- a/org-sliced-images.el
+++ b/org-sliced-images.el
@@ -53,6 +53,14 @@ nearest multiple of the `default-font-height'."
   :type 'boolean
   :group 'org-sliced-images)
 
+(defcustom org-sliced-images-max-sliced-height 0
+  "The maximum allowed height for image slices.
+
+If the value is 0, it means no restriction. If the value is a number greater
+than or equal to 1, it represents the multiple of `default-line-height'."
+  :type 'natnum
+  :group 'org-sliced-images)
+
 ;; Buffer variables
 
 (defvar-local org-sliced-images-inline-image-overlay-families nil
@@ -240,23 +248,35 @@ buffer boundaries with possible narrowing."
                           (image-flush image)
                           (let* ((image-pixel-cons (image-size image t))
                                  (image-pixel-h (cdr image-pixel-cons))
-                                 (font-height (default-font-height)))
+                                 (font-height (default-font-height))
+                                 (sliced-num-for-image (floor image-pixel-h font-height))
+                                 (link-begin (org-element-property :begin link))
+                                 (link-end (org-element-property :end link))
+                                 (link-len (- link-end link-begin))
+                                 (link-supported-sliced-num (floor (1+ link-len) 2)))
                             ;; Round image height
                             (when org-sliced-images-round-image-height
                               (setq image-pixel-h
                                     (truncate (* (fround (/ image-pixel-h font-height 1.0)) font-height)))
+                              (setq sliced-num-for-image (floor image-pixel-h font-height))
                               (setf (image-property image :height) image-pixel-h)
                               (setf (image-property image :width) nil))
-                            (let* ((sliced-num-for-image (floor image-pixel-h font-height))
-                                   (link-begin (org-element-property :begin link))
-                                   (link-end (org-element-property :end link))
-                                   (link-len (- link-end link-begin))
-                                   (link-supported-sliced-num (floor (1+ link-len) 2))
-                                   (sliced-num (min sliced-num-for-image link-supported-sliced-num))
-                                   (front-sliced-height (* font-height (ceiling sliced-num-for-image sliced-num)))
-                                   (front-sliced-num (if (<= sliced-num-for-image link-supported-sliced-num)
-                                                         (1- sliced-num-for-image)
-                                                       (mod sliced-num-for-image link-supported-sliced-num)))
+                            (when (and (> org-sliced-images-max-sliced-height 0)
+                                       (natnump org-sliced-images-max-sliced-height)
+                                       (>= (floor sliced-num-for-image link-supported-sliced-num)
+                                           org-sliced-images-max-sliced-height))
+                              (setq sliced-num-for-image (* link-supported-sliced-num org-sliced-images-max-sliced-height))
+                              (setq image-pixel-h (* sliced-num-for-image font-height))
+                              (setf (image-property image :height) image-pixel-h)
+                              (setf (image-property image :width) nil))
+                            (let* ((sliced-num (min sliced-num-for-image link-supported-sliced-num))
+                                   (calc-sliced-height (floor image-pixel-h sliced-num))
+                                   (max-sliced-height (* org-sliced-images-max-sliced-height font-height))
+                                   (sliced-height (if (and (> org-sliced-images-max-sliced-height 0)
+                                                           (natnump org-sliced-images-max-sliced-height)
+                                                           (> calc-sliced-height max-sliced-height))
+                                                      max-sliced-height
+                                                    calc-sliced-height ))
                                    (img-y 0)
                                    (ovfam nil))
                               (org-with-point-at link-begin
@@ -268,14 +288,12 @@ buffer boundaries with possible narrowing."
                                          (img-text-end (if (< i (1- sliced-num))
                                                            (1+ img-text-start)
                                                          link-end))
-                                         ;; Make sliced images as uniformly tall as possible
-                                         ;; The leading images might be taller, while the subsequent ones could be shorter
-                                         ;; The last sliced image will contain the remaining portion of the image,
+                                         ;; Make sliced images uniformly tall.
+                                         ;; But The last sliced image will contain the remaining portion of the image,
                                          ;; with a height possibly determined by `(mod image-pixel-h font-height)`
-                                         (sliced-img-height (cond
-                                                             ((< i front-sliced-num) front-sliced-height)
-                                                             ((< i (1- sliced-num)) (- front-sliced-height font-height))
-                                                             (t (- image-pixel-h img-y)))))
+                                         (sliced-img-height (if (< i (1- sliced-num))
+                                                                sliced-height
+                                                              (- image-pixel-h img-y))))
                                     (push (org-sliced-images--make-inline-image-overlay
                                            img-text-start img-text-end
                                            (list (list 'slice 0 img-y
@@ -321,7 +339,8 @@ BEG, END, LEN will be passed by the overlay."
 (define-minor-mode org-sliced-images-mode
   "Display images as sliced images in org-mode, like insert-sliced-image. This
 makes scrolling nicer."
-  :group org-sliced-images
+  :global t
+  :group 'org-sliced-images
   (let (display)
     (if org-sliced-images-mode
         (progn


### PR DESCRIPTION
Thank you for developing this package. I really enjoy it.

The current implementation of displaying sliced images directly modifies the file content, which may lead to frequently auto save for me.

I have modified its implementation so that image display no longer alters the file content. Instead, it achieves this by putting overlay on link. However, one drawback is that the image slices may exceed the default font height.